### PR TITLE
Change packpath to pkg-dir, fixes #11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2715,7 +2715,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -4483,7 +4482,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
       "requires": {
         "p-locate": "^4.1.0"
       }
@@ -4925,7 +4923,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -4934,7 +4931,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.2.0"
       }
@@ -4942,13 +4938,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
-    "packpath": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/packpath/-/packpath-0.1.0.tgz",
-      "integrity": "sha1-pSFTQiLf6qnGEu8MZA7DmRSezdg="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -4986,8 +4976,7 @@
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -5145,7 +5134,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Ingar Helgesen (https://github.com/sherex)",
   "license": "MIT",
   "dependencies": {
-    "packpath": "0.1.0",
+    "pkg-dir": "^4.2.0",
     "syslog-client": "^1.1.1"
   },
   "devDependencies": {

--- a/src/lib/get-package-json.js
+++ b/src/lib/get-package-json.js
@@ -1,18 +1,18 @@
-const packPath = require('packpath').parent()
+const pkgDir = require('pkg-dir')
 const { join } = require('path')
 
 const getPkgDeps = {
-  packPath,
+  pkgDir,
   join
 }
-
+console.log(pkgDir.sync())
 function _getPkgFactory (
   {
-    packPath,
+    pkgDir,
     join
   }) {
   try {
-    return require(join(packPath, 'package.json'))
+    return require(join(pkgDir.sync(), 'package.json'))
   } catch (error) {
     return undefined
   }


### PR DESCRIPTION
## Changes
 - [4f8c800087bcd82076dc11bc0ea49b74e7d0cdbb] - Change from using [`packpath`](https://www.npmjs.com/package/packpath) to get the `package.json` for the root project, to using [`pkg-dir`](https://www.npmjs.com/package/pkg-dir).

## Related issues
- Fixes #11