### PR TITLE
Add support for Azure functions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,18 @@ declare module '@vtfk/logger' {
       serviceHostname?: string
       serviceAppname?: string
     }
+    azure?: {
+      context?: {
+        invocationId?: string
+        log?: {
+          error: () => void
+          warn: () => void
+          info: () => void
+          verbose: () => void
+        }
+      }
+      excludeInvocationId?: boolean
+    }
     prefix?: string
     suffix?: string
     localLogger?: (message: any) => void

--- a/src/lib/log-config-factory.js
+++ b/src/lib/log-config-factory.js
@@ -54,6 +54,23 @@ function _logConfigFactory (options = {},
   if (typeof options.localLogger === 'function') {
     loggerOptions.localLogger = options.localLogger
   }
+
+  if (typeof options.azure !== 'undefined' && typeof options.azure.context !== 'undefined') {
+    loggerOptions.azure = {}
+
+    if (typeof options.azure.context.invocationId === 'string') {
+      loggerOptions.azure.invocationId = options.azure.context.invocationId
+    }
+
+    const log = options.azure.context.log
+    if (log && log.error && log.warn && log.info && log.verbose) {
+      loggerOptions.azure.log = log
+    }
+
+    if (options.azure.excludeInvocationId === true) {
+      loggerOptions.azure.excludeInvocationId = options.azure.excludeInvocationId
+    }
+  }
 }
 
 module.exports = _logConfigFactory

--- a/src/lib/log-config-factory.test.js
+++ b/src/lib/log-config-factory.test.js
@@ -265,3 +265,75 @@ describe('Checking client creation', () => {
     expect(fakeDeps.loggerOptions.remoteLogger).not.toBeUndefined()
   })
 })
+
+function createAzureMock (id = '02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4') {
+  return {
+    context: {
+      invocationId: id,
+      log: {
+        error: jest.fn((host, options) => ({})),
+        warn: jest.fn((host, options) => ({})),
+        info: jest.fn((host, options) => ({})),
+        verbose: jest.fn((host, options) => ({}))
+      }
+    }
+  }
+}
+
+describe('Checking usage of Azure context', () => {
+  it('adds invocationId to loggerOptions.azure.invocationId', () => {
+    const { context } = createAzureMock('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+    const { fakeDeps, logConfig } = createLogConfig({})
+    logConfig({
+      azure: { context }
+    })
+    expect(fakeDeps.loggerOptions.azure.invocationId).toBe('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+  })
+
+  it('adds the Azure logger functions to loggerOptions.azure.log[level]', () => {
+    const { context } = createAzureMock('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+    const { fakeDeps, logConfig } = createLogConfig({})
+    logConfig({
+      azure: { context }
+    })
+    expect(fakeDeps.loggerOptions.azure.log.error).toBeFunction()
+    expect(fakeDeps.loggerOptions.azure.log.warn).toBeFunction()
+    expect(fakeDeps.loggerOptions.azure.log.info).toBeFunction()
+    expect(fakeDeps.loggerOptions.azure.log.verbose).toBeFunction()
+  })
+
+  it('adds excludeInvocationId loggerOptions.azure.excludeInvocationId', () => {
+    const { context } = createAzureMock('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+    const { fakeDeps, logConfig } = createLogConfig({})
+    logConfig({
+      azure: {
+        context,
+        excludeInvocationId: true
+      }
+    })
+    expect(fakeDeps.loggerOptions.azure.excludeInvocationId).toBe(true)
+  })
+
+  it('does not add loggerOptions.azure.excludeInvocationId if undefined', () => {
+    const { context } = createAzureMock('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+    const { fakeDeps, logConfig } = createLogConfig({})
+    logConfig({
+      azure: {
+        context
+      }
+    })
+    expect(fakeDeps.loggerOptions.azure.excludeInvocationId).toBeUndefined()
+  })
+
+  it('does not add loggerOptions.azure.excludeInvocationId if false', () => {
+    const { context } = createAzureMock('02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4')
+    const { fakeDeps, logConfig } = createLogConfig({})
+    logConfig({
+      azure: {
+        context,
+        excludeInvocationId: false
+      }
+    })
+    expect(fakeDeps.loggerOptions.azure.excludeInvocationId).toBeUndefined()
+  })
+})

--- a/src/lib/log-config-factory.test.js
+++ b/src/lib/log-config-factory.test.js
@@ -271,7 +271,7 @@ function createAzureMock (id = '02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4', includeLo
     invocationId: id,
     log: {}
   }
-  includeLoggers.forEach(logger => context.log[logger] = jest.fn((host, options) => ({})))
+  includeLoggers.forEach(logger => { context.log[logger] = jest.fn((host, options) => ({})) })
   return { context }
 }
 

--- a/src/lib/log-level-mapper.js
+++ b/src/lib/log-level-mapper.js
@@ -1,22 +1,41 @@
 const levelMapper = {
-  error: 0,
-  warn: 1,
-  info: 2,
-  verbose: 3,
-  debug: 4,
-  silly: 5
+  error: {
+    severity: 0,
+    azureLevel: 'error'
+  },
+  warn: {
+    severity: 1,
+    azureLevel: 'warn'
+  },
+  info: {
+    severity: 2,
+    azureLevel: 'info'
+  },
+  verbose: {
+    severity: 3,
+    azureLevel: 'verbose'
+  },
+  debug: {
+    severity: 4,
+    azureLevel: 'verbose'
+  },
+  silly: {
+    severity: 5,
+    azureLevel: 'verbose'
+  }
 }
 
 const longestLevelString = Object.keys(levelMapper).reduce((prev, curr) => curr.length > prev.length ? curr : prev)
 
 module.exports = (level) => {
   try {
-    const severity = levelMapper[level.toLowerCase()]
-    if (typeof severity === 'number') {
+    const mappedLevel = levelMapper[level.toLowerCase()]
+    if (typeof mappedLevel === 'object') {
       return {
-        severity,
+        severity: mappedLevel.severity,
         level: level.toUpperCase(),
-        padding: ' '.repeat(longestLevelString.length - level.length)
+        padding: ' '.repeat(longestLevelString.length - level.length),
+        azureLevel: mappedLevel.azureLevel
       }
     }
   } catch (error) {

--- a/src/lib/log-level-mapper.test.js
+++ b/src/lib/log-level-mapper.test.js
@@ -39,3 +39,21 @@ describe('Checking if it returns correct value based on level', () => {
     expect(levelMapper(null)).not.toBeDefined()
   })
 })
+
+describe('Checking if it returns correct azureLevel', () => {
+  const levels = [
+    { string: 'error', azureLevel: 'error' },
+    { string: 'warn', azureLevel: 'warn' },
+    { string: 'info', azureLevel: 'info' },
+    { string: 'verbose', azureLevel: 'verbose' },
+    { string: 'debug', azureLevel: 'verbose' },
+    { string: 'silly', azureLevel: 'verbose' },
+    { string: 'INfo', azureLevel: 'info' },
+    { string: 'SILLY', azureLevel: 'verbose' }
+  ]
+  levels.forEach(level => {
+    it(`returns azureLevel: '${level.azureLevel}', when given string '${level.string}'`, () => {
+      expect(levelMapper(level.string).azureLevel).toBe(level.azureLevel)
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes #29.
It will now accept a `context` object from an Azure function and a `excludeInvocationId`.
If a `context` object is added, it will prepend the `invocationId` to the log message (even before the prefix), unless `excludeInvocationId` is `true`.

It will also map the correct log level to context.log[level] like this:
`error` => `context.log.error()`
`warn` => `context.log.warn()`
`info` => `context.log.info()`
`verbose` => `context.log.verbose()`
`debug` => `context.log.verbose()` // Lowest level on Azure is verbose
`silly` => `context.log.verbose()` // Lowest level on Azure is verbose

> This is for some reason not visible when running locally (other than the color of the message), but it shows correctly in the Azure Portal

### Example:
```ts
const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
    logConfig({
        azure: { context },
        prefix: 'kittens'
    })
    logger('error', ['are too cute!'])
    logger('warn', ['can scratch'])
    logConfig({ azure: { excludeInvocationId: true } })
    logger('info', ['are cats'])
};
```
![image](https://user-images.githubusercontent.com/29156282/99651941-82358900-2a57-11eb-8b8f-3855861b2aad.png)
