### PR TITLE
Revert "Update coverallsapp/github-action action to v1.1.2"

### DIFF
--- a/.github/workflows/coveralls-publish.yml
+++ b/.github/workflows/coveralls-publish.yml
@@ -25,6 +25,6 @@ jobs:
         npm run test:coverage
 
     - name: Coveralls
-      uses: coverallsapp/github-action@v1.1.1
+      uses: coverallsapp/github-action@v1.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coveralls-publish.yml
+++ b/.github/workflows/coveralls-publish.yml
@@ -25,6 +25,6 @@ jobs:
         npm run test:coverage
 
     - name: Coveralls
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@v1.1.1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts vtfk/node-shared-logger#32

This version fails with error message:
```
Run coverallsapp/github-action@v1.1.2
  with:
    github-token: ***
    path-to-lcov: ./coverage/lcov.info
    coveralls-endpoint: https://coveralls.io
Using lcov file: ./coverage/lcov.info
Error:  "2020-11-19T10:31:05.625Z"  'error from getOptions'
Error: Error: Command failed: git cat-file -p ad26c8481ba0295795fd1a994836d7bf80d54d9e
fatal: Not a valid object name ad26c8481ba0295795fd1a994836d7bf80d54d9e
```