### PR TITLE
Use `message` or `stack` property on Error objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ const options = {
   },
   prefix: '',                   // A string that will be added in front of each log message (ex. UID for each run)
   suffix: '',                   // A string that will be added at the end of each log message
+  error: {                      // Options for logging out Error object. If undefined; stack from Error object will be returned
+    useMessage: true            // If true; use message from Error object instead of stack
+  }
   localLogger: console.log      // Replace the local logger with a custom function (Default: console.log)
 }
 
@@ -60,6 +63,41 @@ The least amount of code to log to console or a remote syslog aggregator (if opt
 const { logger } = require('@vtfk/logger')
 
 logger('info', ['test', 'message'])
+```
+
+#### Ex. Basic with specifying Error property
+Use logConfig to instruct that message property is used from Error objects
+```js
+const { logConfig, logger } = require('@vtfk/logger')
+
+logConfig({
+  error: {
+    useMessage: true
+  }
+})
+
+logger('info', ['test', 'message'])
+
+logger('warn', ['another', 'action', new Error('Ups. Something happend)])
+
+// OUTPUT 
+// NAME-OF-APP and VER-OF-APP is the value of "name" and "version" in your package.json
+[ 2019-05-19 15:41:17 ] < INFO >  {NAME-OF-APP} - {VER-OF-APP}: - test - message
+[ 2019-05-19 15:41:17 ] < WARN >  {NAME-OF-APP} - {VER-OF-APP}: - another - action - Ups. Something happend
+```
+
+#### Ex. Basic without specifying Error property
+```js
+const { logger } = require('@vtfk/logger')
+
+logger('info', ['test', 'message'])
+
+logger('warn', ['another', 'action', new Error('Ups. Something happend)])
+
+// OUTPUT 
+// NAME-OF-APP and VER-OF-APP is the value of "name" and "version" in your package.json
+[ 2019-05-19 15:41:17 ] < INFO >  {NAME-OF-APP} - {VER-OF-APP}: - test - message
+[ 2019-05-19 15:41:17 ] < WARN >  {NAME-OF-APP} - {VER-OF-APP}: - another - action - Error: Ups. Something happend\n
 ```
 
 #### Ex. Basic with prefix

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const { logger } = require('@vtfk/logger')
 logger('info', ['test', 'message'])
 ```
 
-#### Ex. Basic with preifx
+#### Ex. Basic with prefix
 Use logConfig to display a UID infront of each message
 ```js
 const { logConfig, logger } = require('@vtfk/logger')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A logger for console and Papertrail",
   "main": "src/index.js",
   "scripts": {
-    "test": "jest",
+    "test": "standard && jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "lint": "standard ./src/**/*.js"

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const loggerDeps = {
  * @param {string}    [options.remote.serviceAppname="default:"]   The identificator of this application (defaults to "default:" for consistency with Winston)
  * @param {string}    [options.prefix]                    A string that will be added in front of each log message (ex. UID for each run)
  * @param {string}    [options.suffix]                    A string that will be added at the end of each log message
+ * @param {string}    [options.error.useMessage]          Use message property on error objects, if not set stack property will be used
  * @param {function}  [options.localLogger=console.log]   Replace the local logger with a custom function (Default: console.log)
  * @returns {void}
  */

--- a/src/lib/get-message.js
+++ b/src/lib/get-message.js
@@ -1,0 +1,3 @@
+module.exports = (msg, errorProperty) => {
+  return typeof msg === 'object' ? msg instanceof Error ? msg[errorProperty] : JSON.stringify(msg) : msg
+}

--- a/src/lib/get-message.test.js
+++ b/src/lib/get-message.test.js
@@ -9,37 +9,37 @@ const testFour = new Error('Error object')
 const testFive = 'Log output'
 
 describe('Get message testing', () => {
-  it(`Returns a JSON object as stringified`, () => {
+  it('Returns a JSON object as stringified', () => {
     const testData = getMessage(testOne)
     expect(testData).toBeString()
     expect(testData).toBe('{"objOne":"First obj","objTwo":"Second obj"}')
   })
 
-  it(`Returns a number as a string`, () => {
+  it('Returns a number as a string', () => {
     const testData = getMessage(testTwo)
     expect(testData).toBeNumber()
     expect(testData).toBe(testTwo)
   })
 
-  it(`Returns a JSON array as stringified`, () => {
+  it('Returns a JSON array as stringified', () => {
     const testData = getMessage(testThree)
     expect(testData).toBeString()
     expect(testData).toBe('[{"objThree":"Third obj","objFour":"Fourth obj"}]')
   })
 
-  it(`Returns message property from Error object`, () => {
+  it('Returns message property from Error object', () => {
     const testData = getMessage(testFour, 'message')
     expect(testData).toBeString()
     expect(testData).toBe('Error object')
   })
 
-  it(`Returns stack property from Error object`, () => {
+  it('Returns stack property from Error object', () => {
     const testData = getMessage(testFour, 'stack')
     expect(testData).toBeString()
     expect(testData).toContain('Error: Error object\n')
   })
 
-  it(`Returns a string from a string`, () => {
+  it('Returns a string from a string', () => {
     const testData = getMessage(testFive)
     expect(testData).toBeString()
     expect(testData).toBe(testFive)

--- a/src/lib/get-message.test.js
+++ b/src/lib/get-message.test.js
@@ -1,0 +1,47 @@
+const getMessage = require('./get-message')
+
+const testOne = { objOne: 'First obj', objTwo: 'Second obj' }
+const testTwo = 123
+const testThree = [
+  { objThree: 'Third obj', objFour: 'Fourth obj' }
+]
+const testFour = new Error('Error object')
+const testFive = 'Log output'
+
+describe('Get message testing', () => {
+  it(`Returns a JSON object as stringified`, () => {
+    const testData = getMessage(testOne)
+    expect(testData).toBeString()
+    expect(testData).toBe('{"objOne":"First obj","objTwo":"Second obj"}')
+  })
+
+  it(`Returns a number as a string`, () => {
+    const testData = getMessage(testTwo)
+    expect(testData).toBeNumber()
+    expect(testData).toBe(testTwo)
+  })
+
+  it(`Returns a JSON array as stringified`, () => {
+    const testData = getMessage(testThree)
+    expect(testData).toBeString()
+    expect(testData).toBe('[{"objThree":"Third obj","objFour":"Fourth obj"}]')
+  })
+
+  it(`Returns message property from Error object`, () => {
+    const testData = getMessage(testFour, 'message')
+    expect(testData).toBeString()
+    expect(testData).toBe('Error object')
+  })
+
+  it(`Returns stack property from Error object`, () => {
+    const testData = getMessage(testFour, 'stack')
+    expect(testData).toBeString()
+    expect(testData).toContain('Error: Error object\n')
+  })
+
+  it(`Returns a string from a string`, () => {
+    const testData = getMessage(testFive)
+    expect(testData).toBeString()
+    expect(testData).toBe(testFive)
+  })
+})

--- a/src/lib/logger-factory.js
+++ b/src/lib/logger-factory.js
@@ -1,3 +1,5 @@
+const getMessage = require('./get-message')
+
 function _loggerFactory (level, message,
   {
     formatDateTime,
@@ -35,7 +37,7 @@ function _loggerFactory (level, message,
     }
   }
 
-  messageArray = messageArray.map(msg => typeof msg === 'object' ? msg instanceof Error ? msg[loggerOptions.error.property] : JSON.stringify(msg) : msg)
+  messageArray = messageArray.map(msg => getMessage(msg, loggerOptions.error.property))
   const messageFormats = formatLogMessage(formatDateTime, pkg, logLevel, messageArray)
 
   const shouldLogToRemote = (loggerOptions.logToRemote && !(!inProduction && loggerOptions.onlyInProd)) || false

--- a/src/lib/logger-factory.js
+++ b/src/lib/logger-factory.js
@@ -27,7 +27,15 @@ function _loggerFactory (level, message,
     messageArray.unshift(loggerOptions.azure.invocationId)
   }
 
-  messageArray = messageArray.map(msg => typeof msg === 'object' ? JSON.stringify(msg) : msg)
+  if (typeof loggerOptions.error === 'object') {
+    loggerOptions.error.property = loggerOptions.error.useMessage ? 'message' : 'stack'
+  } else {
+    loggerOptions.error = {
+      property: 'stack'
+    }
+  }
+
+  messageArray = messageArray.map(msg => typeof msg === 'object' ? msg instanceof Error ? msg[loggerOptions.error.property] : JSON.stringify(msg) : msg)
   const messageFormats = formatLogMessage(formatDateTime, pkg, logLevel, messageArray)
 
   const shouldLogToRemote = (loggerOptions.logToRemote && !(!inProduction && loggerOptions.onlyInProd)) || false

--- a/src/lib/logger-factory.test.js
+++ b/src/lib/logger-factory.test.js
@@ -71,6 +71,25 @@ describe('Checking parameters', () => {
 
     expect(localLogger).toContain('{"myKey":"thisValue","my2ndKey":"otherValue"}')
   })
+
+  it('logs error stack if error given but no option', () => {
+    const { logger, mergedFakeDeps } = createLogger()
+    logger('info', [new Error('Fake error')])
+    const localLogger = mergedFakeDeps.loggerOptions.localLogger.mock.calls[0][0]
+
+    expect(localLogger).toContain('Error: Fake error\n')
+  })
+
+  it('logs error message if error given and useMessage in option is set', () => {
+    const { logger, mergedFakeDeps } = createLogger()
+    mergedFakeDeps.loggerOptions.error = {
+      useMessage: true
+    }
+    logger('info', [new Error('Fake error')])
+    const localLogger = mergedFakeDeps.loggerOptions.localLogger.mock.calls[0][0]
+
+    expect(localLogger).toContain('Fake error')
+  })
 })
 
 describe('Syslog severity testing', () => {


### PR DESCRIPTION
Use `message` or `stack` property on Error objects. If object is not of type Error, default is used