### PR TITLE
Added support for showing repository url (if present) in Teams message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Usage
 
 > [!IMPORTANT]  
-> Version 5.x.x and above requires Nodejs 16 or higher
+> Version 5.x.x and above requires Node.js 16 or higher
 
 ## Config
 All options are optional.
@@ -53,7 +53,8 @@ const options = {
     disabled: false,            // If true; disables logging to Microsoft Teams, even if teams config is set
     onlyInProd: true,           // If true; only log to Microsoft Teams when NODE_ENV === 'production' (default is true)
     url: '',                    // Microsoft Teams channel webhook url
-    level: ''                   // Lowest level for log to Microsoft Teams. If not set, all levels will log to Microsoft Teams
+    level: '',                  // Lowest level for log to Microsoft Teams. If not set, all levels will log to Microsoft Teams
+    skipRepo: false             // If true; do not include repo name/url in message. (default is false)
   },
   azure: {                      // Options for Azure
     context: context,           // The context object received from an Azure Function (see example further down)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,8 @@ interface LogConfigOptions {
     disabled?: boolean
     onlyInProd?: boolean
     url?: string
-    level?: Levels
+    level?: Levels,
+    skipRepo?: boolean
   }
   azure?: {
     context?: {

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ const loggerDeps = {
  * @param {string}    [options.teams.url]                 URL to teams webhook
  * @param {string}    [options.teams.level]               Lowest level for log to teams. If not set, defaults to WARN
  * @param {boolean}   [options.teams.disabled]            Disable teams logging
+ * @param {boolean}   [options.teams.skipRepo]            Do not log repository value from package.json, defaults to false
  * @param {string}    [options.prefix]                    A string that will be added in front of each log message (ex. UID for each run)
  * @param {string}    [options.suffix]                    A string that will be added at the end of each log message
  * @param {string}    [options.error.useMessage]          Use message property on error objects. If undefined; stack property will be used

--- a/src/lib/log-config-factory.js
+++ b/src/lib/log-config-factory.js
@@ -86,6 +86,7 @@ function _logConfigFactory (options = {}, { axios, deepmerge, loggerOptions, env
         loggerOptions.betterstackLevel = options.betterstack.level
       }
     }
+
     // Teams logging
     if (options.teams && typeof options.teams === 'object') {
       options.teams.url = options.teams.url || envVariables.TEAMS_WEBHOOK_URL
@@ -107,6 +108,8 @@ function _logConfigFactory (options = {}, { axios, deepmerge, loggerOptions, env
 
       // enables teams logging if everything checks out, otherwise teams logging will be disabled
       loggerOptions.logToTeams = !options.teams.disabled && typeof options.teams.url === 'string'
+
+      loggerOptions.teamsSkipRepo = options.teams.skipRepo === true
 
       // set teams level (lowest level for teams logging)
       loggerOptions.teamsLevel = options.teams.level || 'warn' // Default log level for Teams is set to WARN

--- a/src/lib/logger-factory.js
+++ b/src/lib/logger-factory.js
@@ -31,7 +31,7 @@ async function _loggerFactory (level, message, { formatDateTime, logLevelMapper,
   }
 
   messageArray = messageArray.map(msg => getMessage(msg, loggerOptions.error.property))
-  const messageFormats = formatLogMessage(formatDateTime, pkg, logLevel, messageArray, context)
+  const messageFormats = formatLogMessage(formatDateTime, pkg, logLevel, messageArray, context, loggerOptions)
   const remoteLevel = (loggerOptions.remoteLevel && logLevelMapper(loggerOptions.remoteLevel)) || undefined
   const remoteLevelLogToRemote = remoteLevel ? logLevel.severity <= remoteLevel.severity : true
   const betterstackLevel = (loggerOptions.betterstackLevel && logLevelMapper(loggerOptions.betterstackLevel)) || undefined
@@ -92,24 +92,27 @@ async function _loggerFactory (level, message, { formatDateTime, logLevelMapper,
   return shouldLogToRemote // This is only used for testing - the tests work exactly the same way for both logging to remote and to Teams, if you mess with one of them, you mess with both (the tests)!
 }
 
-function formatLogMessage (formatDateTime, pkg, logLevel, messageArray, context) {
+function formatLogMessage (formatDateTime, pkg, logLevel, messageArray, context, loggerOptions = {}) {
   const { fDate, fTime } = formatDateTime(new Date())
   const invocationId = (context && context.log && context.invocationId) ? ` - ${context.invocationId}` : ''
   const funcDetails = pkg && pkg.version ? `${pkg.name} - ${pkg.version}${invocationId}: ` : ''
   const logMessage = `${funcDetails}${messageArray.join(' - ')}`
+  const teamsRepoString = (loggerOptions.teamsSkipRepo === undefined || loggerOptions.teamsSkipRepo !== true) && pkg && pkg.repository
+    ? (pkg.repository.url || pkg.repository).replace('git+', '').replace('.git', '')
+    : null
 
   return {
     logMessage,
     remoteLogMessage: `${logLevel.level} - ${logMessage}`,
     betterstackLogMessage: logMessage, // Betterstack package will add level and timestamp
     localLogMessage: `[ ${fDate} ${fTime} ] < ${logLevel.level} >${logLevel.padding} ${logMessage}`,
-    teamsMessageCard: formatMessageCard(logLevel, `${logLevel.level} - ${funcDetails}`, messageArray),
-    teamsAdaptiveCard: formatAdaptiveCard(logLevel, `${logLevel.level} - ${funcDetails}`, messageArray)
+    teamsMessageCard: formatMessageCard(logLevel, `${logLevel.level} - ${funcDetails}`, messageArray, teamsRepoString),
+    teamsAdaptiveCard: formatAdaptiveCard(logLevel, `${logLevel.level} - ${funcDetails}`, messageArray, teamsRepoString)
   }
 }
 
-function formatMessageCard (logLevel, title, messageArray) {
-  return {
+function formatMessageCard (logLevel, title, messageArray, repoString) {
+  const messageCard = {
     '@type': 'MessageCard',
     '@context': 'https://schema.org/extensions',
     summary: title,
@@ -123,10 +126,33 @@ function formatMessageCard (logLevel, title, messageArray) {
       }
     ]
   }
+
+  if (repoString) {
+    if (new RegExp("^https://").test(repoString)) {
+      messageCard.potentialAction = [
+        {
+          '@type': 'OpenUri',
+          name: 'Repository',
+          targets: [
+            {
+              os: 'default',
+              uri: repoString
+            }
+          ]
+        }
+      ]
+
+      return messageCard
+    }
+
+    messageCard.sections[0].facts.push({name: 'Repository:', value: repoString})
+  }
+
+  return messageCard
 }
 
-function formatAdaptiveCard (logLevel, title, messageArray) {
-  return {
+function formatAdaptiveCard (logLevel, title, messageArray, repoString) {
+  const adaptiveCard = {
     type: 'message',
     attachments: [
       {
@@ -152,6 +178,31 @@ function formatAdaptiveCard (logLevel, title, messageArray) {
       }
     ]
   }
+
+  if (repoString) {
+    if (new RegExp("^https://").test(repoString)) {
+      adaptiveCard.attachments[0].content.body.push({
+        type: 'ActionSet',
+        actions: [
+          {
+            type: 'Action.OpenUrl',
+            title: 'Repository',
+            url: repoString
+          }
+        ]
+      })
+
+      return adaptiveCard
+    }
+
+    adaptiveCard.attachments[0].content.body.push({
+      type: 'TextBlock',
+      text: `Repository: ${repoString}`,
+      wrap: true
+    })
+  }
+
+  return adaptiveCard
 }
 
 function localLog (loggerOptions, logLevel, messageFormats) {

--- a/tests/lib/log-config-factory.test.js
+++ b/tests/lib/log-config-factory.test.js
@@ -304,6 +304,28 @@ describe('Checking client creation', () => {
     expect(fakeDeps.loggerOptions.suffix).toBe('cats')
     expect(fakeDeps.loggerOptions.remoteLogger).not.toBeUndefined()
   })
+
+  it('supports skipRepo before and after initial config is set', () => {
+    const { fakeDeps, logConfig } = createLogConfig({}, {
+      teams: {
+        skipRepo: true
+      }
+    })
+    expect(fakeDeps.loggerOptions.teamsSkipRepo).toBeTruthy()
+
+    logConfig({
+      teams: {
+        skipRepo: false
+      }
+    })
+    expect(fakeDeps.loggerOptions.teamsSkipRepo).toBeFalsy()
+  })
+
+  it('supports skipRepo to not be set at all', () => {
+    const { fakeDeps } = createLogConfig({}, {
+    })
+    expect(fakeDeps.loggerOptions.teamsSkipRepo).toBeFalsy()
+  })
 })
 
 function createAzureMock (id = '02sd1514-c4dc-4c3a-ae9f-0066bb1da3a4', includeLoggers = ['error', 'warn', 'info', 'verbose']) {


### PR DESCRIPTION
Added support for showing repository url (if present) in Teams message

If `TEAMS_WEBHOOK_URL` is a **Power Automate** URL, add the repository as a clickable link (button). Otherwise show the repository url as a normal TextBlock.

Added option, `option.teams.skipRepo`, to not include repository in Teams message

Closes #96